### PR TITLE
First implementation of the CalibrationTables class

### DIFF
--- a/calibration/__init__.py
+++ b/calibration/__init__.py
@@ -2,19 +2,161 @@
 #
 # Copyright (C) 2018 Stefano Sartor - stefano.sartor@inaf.it
 
+from collections import namedtuple
+import logging as log
+from pathlib import Path
+
+import pandas as pd
+
+from config import Config
+from striptease import (
+    StripConnection,
+    normalize_polarimeter_name,
+    get_polarimeter_index,
+    get_lna_num,
+)
+
+CalibrationCurve = namedtuple(
+    "CalibrationCurve", ["slope", "intercept", "mul", "div", "add",]
+)
 
 
-class Calibration(object):
-    def __init__(self):
-        ## TODO: load calibration curves
-        pass
+def physical_units_to_adu(
+    physical_value, calibration_curve: CalibrationCurve, step=1.0
+):
+    adu = physical_value * step * calibration_curve.slope + calibration_curve.intercept
+    if adu < 0:
+        adu = 0
+    return int(adu + 0.5)
 
-    def calibrate(self,pol,hk,value):
-        ## TODO: given the polarimeter name, the housekeeping and the ADU value
-        ## return the value in phisical units
-        return value
 
-    def reverse(self,pol,hk,value):
-        ## TODO: given the polarimeter name, the housekeeping and the value in
-        ## phisical units return the ADU value
-        return value
+def adu_to_physical_units(adu_value, calibration_curve: CalibrationCurve, step=1.0):
+    return (adu_value - calibration_curve.intercept) / calibration_curve.slope
+
+
+def read_board_xlsx(path):
+    log.debug(f"Reading Excel file {path}")
+    board = []
+    excel_file_data = pd.read_excel(path, header=None, sheet_name=None)
+    for cur_sheet in excel_file_data:
+        cur_sheet_dict = {}
+        pol = excel_file_data[cur_sheet].transpose()
+        line_count = 0
+        current_item = pd.np.nan
+        current_fit = pd.np.nan
+        current_chan = pd.np.nan
+        for r in pol:
+            row = pol[r]
+            if line_count <= 1:
+                line_count += 1
+                continue
+            elif type(row[0]) == str and row[0].strip() == "ITEM":
+                line_count += 1
+                continue
+            else:
+                if type(row[0]) == str:
+                    current_item = row[0].replace("\n", " ")
+                if type(row[1]) == str:
+                    current_fit = row[1].replace("\n", " ")
+                if cur_sheet_dict.get(current_item) is None:
+                    cur_sheet_dict[current_item] = {}
+                if cur_sheet_dict[current_item].get(current_fit) is None:
+                    cur_sheet_dict[current_item][current_fit] = {}
+                cur_sheet_dict[current_item][current_fit][row[2]] = CalibrationCurve(
+                    slope=float(row[3]),
+                    intercept=float(row[4]),
+                    mul=int(row[5]),
+                    div=int(row[6]),
+                    add=int(row[7]),
+                )
+            line_count += 1
+        board.append(cur_sheet_dict)
+    return board
+
+
+def pol_name_to_dict_key(name: str):
+    board_name = name[0]
+    idx = int(name[1])
+
+    return (board_name, idx)
+
+
+class CalibrationTables(object):
+    """Calibration tables used to convert HK ADUs into physical units and back
+    
+    This class loads the calibration tables for housekeeping parameters from
+    a set of Excel files.
+
+    You can pass a :class:`striptease.Config` class to this class. Not
+    doing so is equivalent to the following code::
+
+        from calibration import CalibrationTables
+        from config import Config
+        from striptease import StripConnection
+
+        with StripConnection() as conn:
+            conf = Config()
+            conf.load(conn)
+    
+        cal_tables = CalibrationTables(conf)
+
+    """
+
+    def __init__(self, config=None):
+
+        if not config:
+            with StripConnection() as conn:
+                config = Config()
+                config.load(conn)
+
+        self.conf = config
+
+        # Each of these dictionaries associates a key in the form
+        # (BOARD, POL_IDX) (like "R", 0) with a list of
+        # CalibrationCurve objects
+        self.calibration_curves = {
+            "vdrain": {},
+            "idrain": {},
+            "vgate": {},
+            "vphsw": {},
+            "iphsw": {},
+        }
+
+        base_path = Path(__file__).parent.parent / "data"
+        for cur_board in self.conf.boards:
+            board_name = cur_board["name"]
+            board_id = cur_board["id"]
+            filename = base_path / self.conf.get_board_bias_file(board_id)
+            try:
+                board_conf = read_board_xlsx(filename)
+            except Exception as exc:
+                log.warning(
+                    f"No suitable bias file for board {board_name} found: {exc}"
+                )
+                continue
+
+            for polidx, pol in enumerate(board_conf):
+                key = f"{board_name.upper()}{polidx}"
+                self.calibration_curves["vdrain"][key] = pol["DRAIN"]["SET VOLTAGE"]
+                self.calibration_curves["idrain"][key] = pol["DRAIN"]["SET CURRENT"]
+                self.calibration_curves["vgate"][key] = pol["GATE"]["SET VOLTAGE"]
+                self.calibration_curves["vphsw"][key] = pol["PIN DIODES"]["SET VOLTAGE"]
+                self.calibration_curves["iphsw"][key] = pol["PIN DIODES"]["SET CURRENT"]
+
+    def get_calibration_curve(self, polarimeter, hk, component):
+        hk_key = hk.lower()
+        polarimeter_id = normalize_polarimeter_name(polarimeter)
+        if hk_key in ("vdrain", "idrain", "vgate"):
+            component_id = get_lna_num(component)
+        else:
+            component_id = component
+
+        return self.calibration_curves[hk_key][polarimeter_id][component_id]
+
+    def adu_to_physical_units(self, polarimeter, hk, component, value):
+        calibration_curve = self.get_calibration_curve(polarimeter, hk, component)
+        return adu_to_physical_units(value, calibration_curve=calibration_curve)
+
+    def physical_units_to_adu(self, polarimeter, hk, component, value):
+        calibration_curve = self.get_calibration_curve(polarimeter, hk, component)
+        return physical_units_to_adu(value, calibration_curve=calibration_curve)

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -28,14 +28,6 @@ each polarimeter and allows to query the biases for one polarimeter at time::
     :members:
     :undoc-members:
     :show-inheritance:
-
-Calibration
------------
-
-.. automodule:: calibration
-    :members:
-    :undoc-members:
-    :show-inheritance:
        
 Configuration
 -------------

--- a/docs/hk_calibration.rst
+++ b/docs/hk_calibration.rst
@@ -1,0 +1,97 @@
+Calibration of housekeeping parameters
+======================================
+
+One of the duty of the electronic boards used by Strip is to measure
+instrument parameters like currents, voltages, temperatures, etc.
+These parameters are called `housekeepings` and are vital to monitor
+the status of the instrument. Like scientific samples, housekeeping
+parameters are measured by digital units and are stored as integer
+numbers, nicknamed `ADU` (analog-to-digital unit). Calibration curves
+must be applied to ADU numbers to retrieve a physically meaningful
+unit (e.g., milliampere, Kelvin, etc.). These calibration curves are
+provided in the form of Excel spreadsheets, and `striptease` provides
+a few utilities to ease the conversion between ADUs and physical
+units.
+
+Usage of calibration tables
+---------------------------
+
+The most basic functions to apply calibration tables are provided by
+the class :class:`.CalibrationTables`. This class implements two
+methods, named :meth:`.physical_units_to_adu` and
+:meth:`.adu_to_physical_units`, which perform the two
+conversions::
+
+  from calibration import CalibrationTables
+
+  cal = CalibrationTables()
+  print(cal.physical_units_to_adu(
+      polarimeter="R0",
+      hk="idrain",
+      component="HA1",
+      value=1000,
+  ))
+
+A `CalibrationTable` object connects with the server when the
+constructor is called, because it needs to know which is the
+association between the board name (in the example above, ``R``) and
+the board number used by the electronics. Once the object ``cal`` has
+been constructed, the connection is no longer used. If you have
+already instanced a :class:`Config` object, you can pass it
+to the constructor and it will be reused::
+
+  from calibration import CalibrationTables
+  from config import Config
+  from striptease import StripConnection
+
+  conn = StripConnection()
+  conn.login()
+  
+  config = Config()
+  config.load(conn)
+
+  # Use "conn" and "config"
+  # …
+
+  # Reuse the configuration object
+  cal = CalibrationTables(config)
+
+  
+Low-level calibration functions
+-------------------------------
+
+A calibration curve is stored in a `CalibrationCurve` object, which
+has the following fields:
+
+1. ``slope`` (float)
+
+2. ``intercept`` (float)
+
+3. ``mul`` (int)
+
+4. ``div`` (int)
+ 
+5. ``add`` (int)
+
+The operation carried out by the electronics to convert physical units
+to ADU is the following (integer operations)::
+
+  adu = value * mul / div + add
+
+However, Striptease uses the following floating-point operation::
+
+  adu = int(value * slope + intercept)
+
+These operations are implemented by the functions
+:meth:`calibration.physical_units_to_adu` and
+:meth:`calibration.adu_to_physical_units`, which require a
+`CalibrationCurve` object.
+
+
+Module documentation
+--------------------
+
+.. automodule:: calibration
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to Striptease's documentation!
 
    authentication
    tutorial
+   hk_calibration
    data_interface
    API
    development

--- a/program_turnon/__init__.py
+++ b/program_turnon/__init__.py
@@ -11,79 +11,14 @@ import time
 import csv
 import sys
 import pandas as pd
-from pprint import pprint
+from calibration import physical_units_to_adu
+from striptease import get_lna_num, get_polarimeter_index
 from striptease.biases import InstrumentBiases, BoardCalibration
 from striptease.procedures import StripProcedure
 
 CalibrationCurve = namedtuple(
     "CalibrationCurve", ["slope", "intercept", "mul", "div", "add",]
 )
-
-
-def get_step(v, cal, step):
-    val = v * step * cal.slope + cal.intercept
-    if val < 0:
-        val = 0
-    return int(val + 0.5)
-
-
-def get_polarimeter_index(pol_name):
-    "Return the progressive number of the polarimeter within the board (1…8)"
-
-    if pol_name[0] == "W":
-        return 7
-    else:
-        return int(pol_name[1]) + 1
-
-
-def get_lna_num(name):
-    """Return the number of an LNA, in the range 0…5
-
-    Valid values for `name` can be:
-    - The official name, e.g., HA1
-    - The UniMIB convention, e.g., H0
-    - The JPL convention, e.g., Q1
-    - An integer number, which will be returned identically
-    """
-
-    if type(name) is int:
-        # Assume that the index refers to the proper firmware register
-        return name
-    elif (len(name) == 3) and (name[0:2] in ["HA", "HB"]):
-        # Official names
-        d = {
-            "HA1": 0,
-            "HA2": 2,
-            "HA3": 4,
-            "HB1": 1,
-            "HB2": 3,
-            "HB3": 5,
-        }
-        return d[name]
-    elif (len(name) == 2) and (name[0] == "H"):
-        # UniMiB
-        d = {
-            "H0": 0,
-            "H1": 1,
-            "H2": 2,
-            "H3": 3,
-            "H4": 4,
-            "H5": 5,
-        }
-        return d[name]
-    elif (len(name) == 2) and (name[0] == "Q"):
-        # JPL
-        d = {
-            "Q1": 0,
-            "Q2": 1,
-            "Q3": 2,
-            "Q4": 3,
-            "Q5": 4,
-            "Q6": 5,
-        }
-        return d[name]
-    else:
-        raise ValueError(f"Invalid amplifier name '{name}'")
 
 
 def read_board_xlsx(path):
@@ -223,7 +158,11 @@ class SetupBoard(object):
 
         cmd["pol"] = polarimeter
         cmd["type"] = "BIAS"
-        for c in [("POL_PWR", 1), ("DAC_REF", 1), ("POL_MODE", mode)]: # , ("CLK_REF", 0)]:
+        for c in [
+            ("POL_PWR", 1),
+            ("DAC_REF", 1),
+            ("POL_MODE", mode),
+        ]:  # , ("CLK_REF", 0)]:
             cmd["base_addr"] = c[0]
             cmd["data"] = [c[1]]
 
@@ -336,25 +275,74 @@ class SetupBoard(object):
 
         cmd["pol"] = polarimeter
         cmd["base_addr"] = f"VPIN{index}_SET"
-        cmd["data"] = [get_step(vpin, calib["PIN DIODES"]["SET VOLTAGE"][index], 1.0)]
+        cmd["data"] = [
+            physical_units_to_adu(vpin, calib["PIN DIODES"]["SET VOLTAGE"][index], 1.0)
+        ]
 
         if not self.post_command(url, cmd):
             return
 
         cmd["base_addr"] = f"IPIN{index}_SET"
-        cmd["data"] = [get_step(ipin, calib["PIN DIODES"]["SET CURRENT"][index], 1.0)]
+        cmd["data"] = [
+            physical_units_to_adu(ipin, calib["PIN DIODES"]["SET CURRENT"][index], 1.0)
+        ]
 
         if not self.post_command(url, cmd):
             return
 
     def setup_bias(
-        self, polarimeter, index, bias_dict, param_name, excel_entry, step=1
+        self,
+        polarimeter,
+        index,
+        bias_dict,
+        param_name,
+        excel_entry,
+        value=None,
+        step=1,
     ):
+        """Set the value of a bias to some calibrated value (e.g., μA, mV)
+
+        Args:
+            polarimeter (str): Name of the polarimeter, e.g., `I0`
+
+            index (int): Zero-based index of the bias to set. For
+                `VD0`, the index is 0.
+
+            bias_dict (dict): Dictionary associating `index` with the
+                bias name used in the Excel file containing the
+                calibration parameters. It is needed only if you pass
+                ``None`` to `value`.
+
+            param_name (str): Base name of the parameter to set. If
+                you want to set up ``ID0``, you must pass here ``ID``;
+                the index will be appended automatically.
+
+            excel_entry (2-tuple): Pair of strings identifying the
+                name of the sheet and the row containing the
+                calibration factors for this bias parameter. For
+                instance, for drain currents you must pass the tuple
+                ``("DRAIN", "SET CURRENT")``.
+
+            value (float or None): Calibrated value (i.e., in physical
+                units) to set. If `value` is ``None``, the default
+                nominal value of the bias (read from Excel files) will
+                be used.
+
+            step (float): Multiplication factor used with `value`.
+                This value is multiplied by the parameter `step`
+                before the application, so ``value=None, step=0.5`
+                will set the bias to 50% of its nominal value.
+
+        """
         url = self.conf.get_rest_base() + "/slo"
 
         pol_index = get_polarimeter_index(polarimeter)
+
         bc = self.ib.get_biases(module_name=polarimeter)
         calib = self.bc[f"Pol{pol_index + 1}"]
+        if not value:
+            value = bc.__getattribute__(bias_dict[index])
+
         title1, title2 = excel_entry
 
         cmd = {
@@ -364,20 +352,14 @@ class SetupBoard(object):
             "timeout": 500,
             "pol": polarimeter,
             "base_addr": f"{param_name}{index}_SET",
-            "data": [
-                get_step(
-                    bc.__getattribute__(bias_dict[index]),
-                    calib[title1][title2][index],
-                    step,
-                )
-            ],
+            "data": [physical_units_to_adu(value, calib[title1][title2][index], step)],
         }
 
         if not self.post_command(url, cmd):
             return
 
     def setup_lna_bias(
-        self, polarimeter, lna, bias_dict, param_name, excel_entry, step=1
+        self, polarimeter, lna, bias_dict, param_name, excel_entry, value=None, step=1
     ):
         self.setup_bias(
             polarimeter=polarimeter,
@@ -385,10 +367,11 @@ class SetupBoard(object):
             bias_dict=bias_dict,
             param_name=param_name,
             excel_entry=excel_entry,
+            value=value,
             step=step,
         )
 
-    def setup_VD(self, polarimeter, lna, step=1):
+    def setup_VD(self, polarimeter, lna, value=None, step=1):
         vd = {
             0: "vd0",
             1: "vd1",
@@ -404,10 +387,11 @@ class SetupBoard(object):
             bias_dict=vd,
             param_name="VD",
             excel_entry=("DRAIN", "SET VOLTAGE"),
+            value=None,
             step=step,
         )
 
-    def setup_VG(self, polarimeter, lna, step=1):
+    def setup_VG(self, polarimeter, lna, value=None, step=1):
         vg = {
             0: "vg0",
             1: "vg1",
@@ -425,10 +409,11 @@ class SetupBoard(object):
             bias_dict=vg,
             param_name="VG",
             excel_entry=("GATE", "SET VOLTAGE"),
+            value=value,
             step=step,
         )
 
-    def setup_ID(self, polarimeter, lna, step=1):
+    def setup_ID(self, polarimeter, lna, value=None, step=1):
         id = {
             0: "id0",
             1: "id1",
@@ -444,6 +429,7 @@ class SetupBoard(object):
             bias_dict=id,
             param_name="ID",
             excel_entry=("DRAIN", "SET CURRENT"),
+            value=value,
             step=step,
         )
 
@@ -543,7 +529,7 @@ class TurnOnOffProcedure(StripProcedure):
             seconds once the polarimeter has been fully turned on.                         
         """
 
-        assert self.horn
+        assert not (self.horn is None)
         board_setup = SetupBoard(
             config=self.conf, board_name=self.board, post_command=self.command_emitter
         )

--- a/test/test_calibration.py
+++ b/test/test_calibration.py
@@ -1,0 +1,10 @@
+# -*- encoding: utf-8 -*-
+
+from calibration import CalibrationTables
+
+
+def test_calibration():
+    cal_tables = CalibrationTables()
+    assert cal_tables.physical_units_to_adu("R0", "idrain", "HA1", 1000) == 180
+    # W3 belongs to the R board
+    assert cal_tables.physical_units_to_adu("W3", "vdrain", "HA1", 156) == 256

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+
+from striptease import normalize_polarimeter_name, get_polarimeter_index, get_lna_num
+
+
+def test_normalize_polarimeter_name():
+    assert normalize_polarimeter_name("R3") == "R3"
+    assert normalize_polarimeter_name("O7") == "O7"
+    assert normalize_polarimeter_name("W3") == "R7"
+
+
+def test_get_polarimeter_index():
+    assert get_polarimeter_index("R0") == 0
+    assert get_polarimeter_index("O4") == 4
+    assert get_polarimeter_index("W4") == 7
+
+
+def test_get_lna_num():
+    for lnaidx, lnaname in enumerate(["HA1", "HB1", "HA2", "HB2", "HA3", "HB3"]):
+        assert get_lna_num(lnaname) == lnaidx
+
+    for lnaidx, lnaname in enumerate(["H0", "H1", "H2", "H3", "H4", "H5"]):
+        assert get_lna_num(lnaname) == lnaidx
+
+    for lnaidx, lnaname in enumerate(["Q1", "Q2", "Q3", "Q4", "Q5", "Q6"]):
+        assert get_lna_num(lnaname) == lnaidx
+
+    for lnaidx, lnaname in enumerate(range(6)):
+        assert get_lna_num(lnaname) == lnaidx


### PR DESCRIPTION
This PR aims to provide a general `CalibrationTables` class that can convert physical units to ADU values and vice versa for housekeeping parameters. It incorporates code that was originally put in `program_turnon`, but which should really be made general.