### PR TITLE
Improve the formatting of JSON procedures

### DIFF
--- a/join_scripts.py
+++ b/join_scripts.py
@@ -3,6 +3,7 @@
 
 import json
 import sys
+from striptease import dump_procedure_as_json
 
 
 def main():
@@ -24,7 +25,7 @@ Example:
         with open(curfilename, "rt") as inpf:
             commands += json.load(inpf)
 
-    json.dump(commands, sys.stdout, indent=4)
+    dump_procedure_as_json(sys.stdout, commands)
 
 
 if __name__ == "__main__":

--- a/program_ivcurves.py
+++ b/program_ivcurves.py
@@ -11,12 +11,12 @@ from calibration import CalibrationTables
 from striptease import (
     STRIP_BOARD_NAMES,
     BOARD_TO_W_BAND_POL,
+    StripProcedure,
     StripTag,
     get_lna_num,
     get_lna_list,
 )
 from striptease.biases import InstrumentBiases
-from striptease.procedures import StripProcedure
 from program_turnon import TurnOnOffProcedure
 
 

--- a/program_open_closed_loop.py
+++ b/program_open_closed_loop.py
@@ -13,11 +13,11 @@ from calibration import CalibrationTables
 from striptease import (
     OPEN_LOOP_MODE,
     CLOSED_LOOP_MODE,
+    StripProcedure,
     StripTag,
     normalize_polarimeter_name,
 )
 from striptease import InstrumentBiases, BiasConfiguration, DataFile
-from striptease.procedures import StripProcedure
 from program_turnon import TurnOnOffProcedure
 
 # Used to look for tags in HDF5 files

--- a/program_pinchoff.py
+++ b/program_pinchoff.py
@@ -6,11 +6,11 @@ import logging as log
 from calibration import CalibrationTables
 from striptease import (
     STRIP_BOARD_NAMES,
+    StripProcedure,
     StripTag,
     polarimeter_iterator,
     wait_with_tag,
 )
-from striptease.procedures import StripProcedure
 from program_turnon import TurnOnOffProcedure
 
 

--- a/program_turnon.py
+++ b/program_turnon.py
@@ -98,11 +98,4 @@ Usage example:
         proc.set_board_horn_polarimeter(args.board, cur_horn, cur_polarimeter)
         proc.run()
 
-    import json
-
-    output = json.dumps(proc.get_command_list(), indent=4)
-    if args.output_filename == "":
-        print(output)
-    else:
-        with open(args.output_filename, "wt") as outf:
-            outf.write(output)
+    proc.output_json(args.output_filename)

--- a/program_turnon/__init__.py
+++ b/program_turnon/__init__.py
@@ -8,9 +8,8 @@ import sys
 import pandas as pd
 import numpy as np
 from calibration import physical_units_to_adu
-from striptease import get_lna_num, get_polarimeter_index
+from striptease import get_lna_num, get_polarimeter_index, StripProcedure
 from striptease.biases import InstrumentBiases, BoardCalibration
-from striptease.procedures import StripProcedure
 
 CalibrationCurve = namedtuple(
     "CalibrationCurve", ["slope", "intercept", "mul", "div", "add"]

--- a/striptease/__init__.py
+++ b/striptease/__init__.py
@@ -37,6 +37,10 @@ from .hdf5files import (
     DataFile,
     scan_data_path,
 )
+from .procedures import (
+    dump_procedure_as_json,
+    StripProcedure,
+)
 from .stripconn import (
     StripConnection,
     StripTag,
@@ -89,6 +93,9 @@ __all__ = [
     "get_hk_descriptions",
     "DataFile",
     "scan_data_path",
+    # procedures.py
+    "dump_procedure_as_json",
+    "StripProcedure",
     # stripconn.py
     "StripConnection",
     "StripTag",

--- a/striptease/procedures.py
+++ b/striptease/procedures.py
@@ -3,10 +3,67 @@
 from copy import deepcopy
 from urllib.parse import urlparse
 import json
+import sys
 
 from config import Config
 from striptease import StripConnection
 from striptease.biases import InstrumentBiases
+
+
+def dump_procedure_as_json(outf, obj, indent_level=0, use_newlines=True):
+    """
+    Dump a list of commands into a JSON file.
+
+    This is similar to what the standard function ``json.dump`` does,
+    but it uses less carriage returns to make the output easier to
+    read and to search with ``grep``.
+    """
+
+    def dump_newline():
+        if use_newlines:
+            outf.write("\n")
+            outf.write(" " * indent_level)
+
+    if isinstance(obj, list):
+        outf.write("[")
+        indent_level += 2
+        dump_newline()
+
+        for idx, elem in enumerate(obj):
+            dump_procedure_as_json(
+                outf, elem, indent_level=indent_level, use_newlines=use_newlines
+            )
+            if idx < len(obj) - 1:
+                outf.write(", ")
+            dump_newline()
+        indent_level -= 2
+        outf.write("]")
+    elif isinstance(obj, dict):
+        outf.write("{")
+        indent_level += 2
+        dump_newline()
+
+        use_newlines_here = use_newlines and (
+            obj.get("kind", "") not in ["tag", "command"]
+        )
+
+        for idx, elem in enumerate(obj):
+            outf.write(f'"{elem}": ')
+            dump_procedure_as_json(
+                outf,
+                obj[elem],
+                indent_level=indent_level,
+                use_newlines=use_newlines_here,
+            )
+            if idx < len(obj) - 1:
+                outf.write(", ")
+
+            if use_newlines_here:
+                dump_newline()
+        indent_level -= 2
+        outf.write("}")
+    else:
+        outf.write(json.dumps(obj))
 
 
 class JSONCommandEmitter:
@@ -114,10 +171,8 @@ class StripProcedure:
                 printed to ``stdout``.
 
         """
-        output = json.dumps(self.get_command_list(), indent=4)
-
         if (not output_filename) or (output_filename == ""):
-            print(output)
+            dump_procedure_as_json(sys.stdout, self.get_command_list())
         else:
             with open(str(output_filename), "wt") as outf:
-                outf.write(output)
+                dump_procedure_as_json(outf, self.get_command_list())

--- a/striptease/procedures.py
+++ b/striptease/procedures.py
@@ -6,7 +6,7 @@ import json
 import sys
 
 from config import Config
-from striptease import StripConnection
+from striptease.stripconn import StripConnection
 from striptease.biases import InstrumentBiases
 
 
@@ -19,7 +19,7 @@ def dump_procedure_as_json(outf, obj, indent_level=0, use_newlines=True):
     read and to search with ``grep``.
     """
 
-    def dump_newline():
+    def dump_newline(indent_level):
         if use_newlines:
             outf.write("\n")
             outf.write(" " * indent_level)
@@ -27,7 +27,7 @@ def dump_procedure_as_json(outf, obj, indent_level=0, use_newlines=True):
     if isinstance(obj, list):
         outf.write("[")
         indent_level += 2
-        dump_newline()
+        dump_newline(indent_level)
 
         for idx, elem in enumerate(obj):
             dump_procedure_as_json(
@@ -35,17 +35,20 @@ def dump_procedure_as_json(outf, obj, indent_level=0, use_newlines=True):
             )
             if idx < len(obj) - 1:
                 outf.write(", ")
-            dump_newline()
+            dump_newline(indent_level)
         indent_level -= 2
         outf.write("]")
     elif isinstance(obj, dict):
+        # A better visually-looking alternative (which however does not work
+        # well with `grep` is
+        #
+        #     use_newlines and (obj.get("kind", "") in ["log"])
+        use_newlines_here = False
+
         outf.write("{")
         indent_level += 2
-        dump_newline()
-
-        use_newlines_here = use_newlines and (
-            obj.get("kind", "") not in ["tag", "command"]
-        )
+        if use_newlines_here:
+            dump_newline(indent_level)
 
         for idx, elem in enumerate(obj):
             outf.write(f'"{elem}": ')
@@ -59,7 +62,7 @@ def dump_procedure_as_json(outf, obj, indent_level=0, use_newlines=True):
                 outf.write(", ")
 
             if use_newlines_here:
-                dump_newline()
+                dump_newline(indent_level)
         indent_level -= 2
         outf.write("}")
     else:


### PR DESCRIPTION
With this PR, JSON procedures are now formatted with one command per line. This permits to use `grep` more effectively to find commands in procedures.

Here are a few examples, which show that now the output of `grep` includes the boards, polarimeters, parameters and data passed to the command:

```sh
# Assume that we have created a procedure named `open_closed_loop_B6.json`
$ grep POL_RCL open_closed_loop_B6.json
  {"path": "/rest/slo", "kind": "command", "command": {"board": "B", "pol": "BOARD", "type": "BIAS", "method": "SET", "timeout": 500, "base_addr": "POL_RCL", "data": [23295]}},
$ grep VG0_SET open_closed_loop_B6.json
  {"path": "/rest/slo", "kind": "command", "command": {"board": "B", "type": "BIAS", "method": "SET", "timeout": 500, "pol": "B6", "base_addr": "VG0_SET", "data": [1204]}}, 
  {"path": "/rest/slo", "kind": "command", "command": {"board": "B", "pol": "B6", "base_addr": "VG0_SET", "type": "BIAS", "method": "SET", "timeout": 500, "data": [2500]}}, 
```

Before this PR, this would have been the output:

```sh
$ grep POL_RCL open_closed_loop_B6.json
      "base_addr": "POL_RCL",
$ grep VG0_SET open_closed_loop_B6.json
      "base_addr": "VG0_SET",
      "base_addr": "VG0_SET",
```
