### PR TITLE
Improve the performance of the HDF5 storage database

### DIFF
--- a/build_hdf5_database.py
+++ b/build_hdf5_database.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- encoding: utf-8 -*-
+
+from argparse import ArgumentParser
+from pathlib import Path
+import logging as log
+from rich.logging import RichHandler
+
+from striptease import DataStorage
+
+
+DEFAULT_DATABASE_NAME = "index.db"
+
+
+def main():
+    parser = ArgumentParser(prog="build_hdf5_database.py")
+    parser.add_argument(
+        "--database-name",
+        "-d",
+        type=str,
+        default=DEFAULT_DATABASE_NAME,
+        help="""Name of the file that will contain the database.
+        The default is {default}""".format(
+            default=DEFAULT_DATABASE_NAME
+        ),
+    )
+    parser.add_argument(
+        "--start-from-scratch",
+        action="store_true",
+        default=False,
+        help="""If true, any existing database will be removed and a new one will
+        be created from scratch. CAUTION: this might take a lot of time!""",
+    )
+    parser.add_argument("path", type=str, help="Path where the HDF5 files are stored")
+    args = parser.parse_args()
+
+    path = Path(args.path)
+
+    log.basicConfig(level="INFO", format="%(message)s", handlers=[RichHandler()])
+
+    log.info(f'looking for a database in "{path}" with name "{args.database_name}"')
+
+    db_path = path / args.database_name
+    if db_path.is_file():
+        log.info(f'an existing database has been found in "{path}"')
+
+        if args.start_from_scratch:
+            log.info(
+                '"--start-from-scratch" was specified, so I am removing the database'
+            )
+            db_path.unlink()
+            log.info(f'database "{db_path}" was removed from disk')
+
+    log.info("going to scan {path} for HDF5 files…")
+    ds = DataStorage(path, database_name=args.database_name, update_database=True)
+    log.info(
+        "the database has been updated and now contains {} entries".format(
+            len(ds.get_list_of_files())
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/data_interface.rst
+++ b/docs/data_interface.rst
@@ -164,6 +164,17 @@ Note that the script provides the range of times as a MJD range; the
 which files contain this information and reads them. The return value
 is the same as for a call to :meth:`.DataFile.load_hk`.
 
+For the class :class:`.DataStorage` to work, a database of the HDF5
+files in the specified path must be already present. You can create
+one using the command-line script ``build_hdf5_database.py``:
+
+.. code-block:: text
+
+  ./build_hdf5_database.py /storage/strip
+
+Accessing data in a storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 The :class:`.DataStorage` provides the following methods to access
 tags, scientific data and housekeeping parameters:
 
@@ -182,4 +193,5 @@ object using the method :meth:`.DataStorage.get_list_of_files()`,
 which returns a list of :`.HDF5FileInfo` objects.
 
 .. autoclass:: striptease.HDF5FileInfo
+
 

--- a/docs/data_interface.rst
+++ b/docs/data_interface.rst
@@ -176,3 +176,10 @@ end MJD or a :class:`.Tag` object that specifies the time range.
 
 .. autoclass:: striptease.DataStorage
    :members:
+
+You can access a list of the files indexed by a :class:`.DataStorage`
+object using the method :meth:`.DataStorage.get_list_of_files()`,
+which returns a list of :`.HDF5FileInfo` objects.
+
+.. autoclass:: striptease.HDF5FileInfo
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ scipy~=1.7.0
 flake8~=4.0.1
 pre-commit~=2.15.0
 openpyxl~=3.0.9
+rich~=10.14.0

--- a/striptease/__init__.py
+++ b/striptease/__init__.py
@@ -31,6 +31,7 @@ from .diagnostics import (
 )
 from .hdf5db import (
     DataStorage,
+    HDF5FileInfo,
 )
 from .hdf5files import (
     Tag,
@@ -91,6 +92,7 @@ __all__ = [
     "plot_tagevents",
     # hdf5db.py
     "DataStorage",
+    "HDF5FileInfo",
     # hdf5files.py
     "Tag",
     "HkDescriptionList",

--- a/striptease/hdf5db.py
+++ b/striptease/hdf5db.py
@@ -238,6 +238,22 @@ class DataStorage:
     def _open_file(self, path: Union[str, Path]) -> DataFile:
         return self.opened_files.get(Path(path), DataFile(path))
 
+    def get_list_of_files(self) -> List[HDF5FileInfo]:
+        """Return a list of all the files in the storage path"""
+        curs = self.db.cursor()
+        curs.execute(
+            """
+            SELECT path, size_in_bytes, first_sample, last_sample
+            FROM files
+            ORDER BY first_sample
+        """
+        )
+
+        return [
+            HDF5FileInfo(path=x[0], size=x[1], mjd_range=(x[2], x[3]))
+            for x in curs.fetchall()
+        ]
+
     def _files_in_range(
         self,
         mjd_interval: Tuple[float, float],

--- a/striptease/hdf5db.py
+++ b/striptease/hdf5db.py
@@ -12,7 +12,17 @@ import numpy as np
 from .hdf5files import DataFile, Tag
 
 
-FileEntry = namedtuple("FileEntry", ["path", "size", "mjd_range"])
+#: Basic information about a HDF5 data file
+#:
+#: Fields are:
+#:
+#: - ``path``: a ``pathlib.Path`` object containing the path to the file
+#:
+#: - ``size``: size of the file, in bytes
+#:
+#: - ``mjd_range``: a 2-tuple containing the MJD of the first and last
+#:   scientific/housekeeping sample in the file (``float`` values)
+HDF5FileInfo = namedtuple("HDF5FileInfo", ["path", "size", "mjd_range"])
 
 
 def extract_mjd_range(
@@ -160,7 +170,7 @@ def scan_data_path(
     return db
 
 
-def find_time_in_files(files: List[FileEntry], mjd: float, first=0, last=None):
+def find_time_in_files(files: List[HDF5FileInfo], mjd: float, first=0, last=None):
     """Search the HDF5 file that contains the specified MJD
 
     This is a textbook-like implementation of a binary search. Therefore, it is
@@ -231,7 +241,7 @@ class DataStorage:
     def _files_in_range(
         self,
         mjd_interval: Tuple[float, float],
-    ) -> List[FileEntry]:
+    ) -> List[HDF5FileInfo]:
         """Return a list of the files that contain data within the MJD range"""
 
         first_mjd, last_mjd = mjd_interval
@@ -254,7 +264,7 @@ class DataStorage:
         )
 
         return [
-            FileEntry(path=x[0], size=x[1], mjd_range=(x[2], x[3]))
+            HDF5FileInfo(path=x[0], size=x[1], mjd_range=(x[2], x[3]))
             for x in curs.fetchall()
         ]
 

--- a/striptease/hdf5db.py
+++ b/striptease/hdf5db.py
@@ -98,8 +98,8 @@ def scan_data_path(
         if not update_database:
             log.warning(
                 (
-                    "file {file_name} is not in database {db_path}"
-                    ", consider using update_database=True"
+                    "file {file_name} is not in database {db_path} or has a "
+                    "wrong MJD range, consider using update_database=True"
                 ).format(file_name=file_name, db_path=db_path)
             )
         else:

--- a/striptease/hdf5files.py
+++ b/striptease/hdf5files.py
@@ -343,8 +343,9 @@ class DataFile:
 
     """
 
-    def __init__(self, filepath):
+    def __init__(self, filepath, filemode="r"):
         self.filepath = Path(filepath)
+        self.filemode = filemode
 
         try:
             self.datetime = parse_datetime_from_filename(self.filepath)
@@ -398,7 +399,7 @@ class DataFile:
                 self.hdf5_file.close()
                 del self.hdf5_file
 
-        self.hdf5_file = h5py.File(self.filepath, "r")
+        self.hdf5_file = h5py.File(self.filepath, self.filemode)
 
         self.hdf5_groups = list(self.hdf5_file)
 
@@ -425,7 +426,8 @@ class DataFile:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close_file()
+        self.hdf5_file.close()
+        del self.hdf5_file
 
     def load_hk(self, group, subgroup, par, verbose=False):
         """Loads scientific data from one detector of a given polarimeter

--- a/test/test_hdf5db.py
+++ b/test/test_hdf5db.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 from dataclasses import dataclass
+import sqlite3
 from typing import Tuple
 
 from striptease import (
@@ -17,20 +18,39 @@ def test_hdf5db(tmp_path: str):
     # We pass an empty path, so we are sure that the list of files will be empty
     ds = DataStorage(tmp_path)
 
-    # Fill the list with some mock objects
-    ds.file_list = [
-        MockDataFile(mjd_range=(0.0, 1.0)),
-        MockDataFile(mjd_range=(1.1, 2.0)),
-        MockDataFile(mjd_range=(2.1, 5.0)),  # There is a gap after this file
-        MockDataFile(mjd_range=(8.1, 9.0)),
-    ]
+    ds.db = sqlite3.connect(":memory:")
+    ds.db.execute(
+        """
+CREATE TABLE IF NOT EXISTS files(
+    path TEXT,
+    size_in_bytes NUMBER,
+    first_sample REAL,
+    last_sample REAL
+)
+    """
+    )
+    ds.db.executemany(
+        "INSERT INTO files VALUES (:path, 0, :first_sample, :last_sample)",
+        [
+            ("a", 0.0, 1.0),
+            ("b", 1.1, 2.0),
+            ("c", 2.1, 5.0),  # There is a gap after this file
+            ("d", 8.1, 9.0),
+        ],
+    )
+    ds.db.commit()
 
-    assert ds._files_in_range((0.2, 0.8)) == [0]
-    assert ds._files_in_range((0.2, 1.8)) == [0, 1]
-    assert ds._files_in_range((0.2, 2.0)) == [0, 1]
-    assert ds._files_in_range((1.0, 1.9)) == [0, 1]
-    assert ds._files_in_range((8.4, 8.5)) == [3]
-    assert ds._files_in_range((0.0, 10.0)) == [0, 1, 2, 3]
+    def get_file_names(file_entries):
+        # ds._files_in_range returns a FileEntry type, but for these
+        # tests we are only interested in the name (first field)
+        return [x[0] for x in file_entries]
+
+    assert get_file_names(ds._files_in_range((0.2, 0.8))) == ["a"]
+    assert get_file_names(ds._files_in_range((0.2, 1.8))) == ["a", "b"]
+    assert get_file_names(ds._files_in_range((0.2, 2.0))) == ["a", "b"]
+    assert get_file_names(ds._files_in_range((1.0, 1.9))) == ["a", "b"]
+    assert get_file_names(ds._files_in_range((8.4, 8.5))) == ["d"]
+    assert get_file_names(ds._files_in_range((0.0, 10.0))) == ["a", "b", "c", "d"]
 
     # Out-of-bounds times
     assert not ds._files_in_range((-3.0, -1.0))


### PR DESCRIPTION
After a few trials, it appears that the original implementation of `DataStorage` is way too slow. This PR makes sure that when a `DataStorage` object is instantiated, it **never** tries to update the database if some information is missing. The price to pay is that the user might not «see» the newest HDF5 files that have been saved to disk.

For this purpose, I have created a new script, `build_hdf5_database.py`, which must be called whenever the database needs to be updated.
