### PR TITLE
Add support for compressed HDF5 files

### DIFF
--- a/build_hdf5_database.py
+++ b/build_hdf5_database.py
@@ -51,7 +51,7 @@ def main():
             db_path.unlink()
             log.info(f'database "{db_path}" was removed from disk')
 
-    log.info("going to scan {path} for HDF5 files…")
+    log.info(f"going to scan {path} for HDF5 files…")
     ds = DataStorage(path, database_name=args.database_name, update_database=True)
     log.info(
         "the database has been updated and now contains {} entries".format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ flake8~=4.0.1
 pre-commit~=2.15.0
 openpyxl~=3.0.9
 rich~=10.14.0
+pyzstd~=0.15.0

--- a/striptease/__init__.py
+++ b/striptease/__init__.py
@@ -34,6 +34,12 @@ from .hdf5db import (
     HDF5FileInfo,
 )
 from .hdf5files import (
+    HDF5_GZIP_FILE_SUFFIXES,
+    HDF5_BZIP2_FILE_SUFFIXES,
+    HDF5_ZSTD_FILE_SUFFIXES,
+    HDF5_XZ_FILE_SUFFIXES,
+    HDF5_RAW_FILE_SUFFIXES,
+    HDF5_FILE_SUFFIXES,
     Tag,
     HkDescriptionList,
     find_first_and_last_samples_in_hdf5,
@@ -94,6 +100,12 @@ __all__ = [
     "DataStorage",
     "HDF5FileInfo",
     # hdf5files.py
+    "HDF5_GZIP_FILE_SUFFIXES",
+    "HDF5_BZIP2_FILE_SUFFIXES",
+    "HDF5_ZSTD_FILE_SUFFIXES",
+    "HDF5_XZ_FILE_SUFFIXES",
+    "HDF5_RAW_FILE_SUFFIXES",
+    "HDF5_FILE_SUFFIXES",
     "Tag",
     "HkDescriptionList",
     "find_first_and_last_samples_in_hdf5",

--- a/striptease/hdf5db.py
+++ b/striptease/hdf5db.py
@@ -9,7 +9,7 @@ from typing import Union, List, Tuple, Set, Dict
 from rich.progress import track
 import numpy as np
 
-from .hdf5files import DataFile, Tag
+from .hdf5files import HDF5_FILE_SUFFIXES, DataFile, Tag
 
 
 #: Basic information about a HDF5 data file
@@ -80,7 +80,12 @@ def scan_data_path(
 
     curs = db.cursor()
     visited_files = set()  # type: Set[str]
-    files_to_update = list(Path(path).glob("**/*.h5"))
+
+    files_to_update = []  # type: List[Path]
+    for cur_suffix in HDF5_FILE_SUFFIXES:
+        files_to_update += list(Path(path).glob(f"**/*{cur_suffix}"))
+
+    log.info(f"{len(files_to_update)} files match the glob pattern")
     for file_name in track(files_to_update) if update_database else files_to_update:
         # Follow symlinks and remove "." and ".."
         file_name = file_name.resolve()

--- a/striptease/hdf5files.py
+++ b/striptease/hdf5files.py
@@ -310,7 +310,8 @@ def _open_file(filepath, filemode):
     elif suffix in HDF5_XZ_FILE_SUFFIXES:
         decompressor_fn = lzma.decompress
     elif suffix in HDF5_RAW_FILE_SUFFIXES:
-        decompressor_fn = gzip.decompress
+        # In this case we just call h5py.File with no pre-loading
+        return h5py.File(filepath, filemode)
 
     assert filemode == "r", "Compressed HDF5 files are read-only"
     assert (


### PR DESCRIPTION
From a few tests I did, it seems that we can gain significant advantages in using compression schemes against HDF5 files.

The HDF5 file format implements in-file compression, but the supported schemes are only a few (`gzip` being the most interesting one). This PR lets the `DataFile` class read HDF5 files compressed using any of the following programs:

- `gzip`
- `bzip2`
- `zstd`
- `xz`

I did several tests considering the following factors:

- Type of HDF5 file: were all the polarimeters turned on, or only a few?
- Compression speed
- Decompression speed
- Compression ratio, i.e., how many times was the compressed file smaller than the original one? (Compression ratio 2: the file halved its size).

From the few tests I did, the best compressor is `xz`, which however takes ~20 minutes to compress a file (decompressing it is a matter of a few seconds). The best compromise is `zstd`, which produces files a bit larger than `xz`, but both compression and decompression are very fast (usually 10÷30 seconds for compression, ~4÷5 seconds for decompression). I would not bother with `gzip`, which produces sub-optimal compression ratios (`.gz` files are up to ×10 times larger than `.zst` and `.xz` files), and `bzip2`, which produces files only marginally smaller than `gzip` at the expense of a significantly larger processing time (several minutes).

Assuming we adopt `zstd` as the standard compressor, we can expect these results:

- Compression ratio is ~2 if all the polarimeters are on, but this improves up to ~100 (yes, one hundred!) if only some polarimeters are being exercised. For instance, test files acquired while running phase switch I/V curves went from 4 GB down to ~30 MB.
- The time required to access data in a file acquired when all the polarimeters are on will be larger, but on files like the phase switch I/V curves mentioned above, the processing speed is increased by a factor ~3, because `zstd` decompression is much faster than file I/O. (In other words, it takes less time to read 30 MB from disk and decompress them than to read 4 GB from disk.) Thus, it will be wise to choose which files should be compressed and which ones should be left untouched.

With this PR in place, you can compress HDF5 files from the command line with commands like:

```sh
$ zstd my_file.h5  # This creates file "my_file.h5.zst"
```

and then read them using

```python
from striptease import DataFile

with DataFile("my_file.h5.zst") as inpf:
    # Use inpf as a normal DataFile
    …
```

The PR fixes `hdf5db.py` too, so that databases of HDF5 files include compressed files as well.