### PR TITLE
Fix a few tags used in turnoff procedure

### DIFF
--- a/turnon/__init__.py
+++ b/turnon/__init__.py
@@ -698,8 +698,8 @@ class TurnOnOffProcedure(StripProcedure):
         # 2
         with StripTag(
             conn=self.command_emitter,
-            name="ELECTRONICS_DISABLE",
-            comment=f"Enabling electronics for {self.horn}",
+            name="ELECTRONICS_DISABLE_{self.horn}",
+            comment=f"Disabling electronics for {self.horn}",
         ):
             board_setup.log(f"Disabling electronics for {self.horn}…")
             board_setup.disable_electronics(polarimeter=self.horn)


### PR DESCRIPTION
To quickly check when a polarimeter was on and when it was off, tags can be used effectively. However, the turnon/turnoff procedure does not provide enough information in the tag name `ELECTRONICS_DISABLE`, unlike the corresponding tag `ELECTRONICS_ENABLE_??` in the turnon procedure (where the `??` is the name of the polarimeter, e.g., `W3`).

This PR fixes this small inconsistency.
