### PR TITLE
Produce PH/SW test procedures that do not rely on unit-level tests

### DIFF
--- a/create_phsw_procedures.sh
+++ b/create_phsw_procedures.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-readonly pre_acquisition_time_proc1_s=606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060
+readonly pre_acquisition_time_proc1_s=60
 readonly pre_acquisition_time_proc2_s=1800
 
 readonly output_dir="$1"
@@ -17,36 +17,50 @@ fi
 # Create the directory, if it does not exist
 mkdir -p "$output_dir"
 
-for board in R O Y G B V I; do
-	python3 program_phsw_curves.py \
-		--pre-acquisition-time $pre_acquisition_time_proc1_s \
-		--output "${output_dir}/phsw_curves_${board}_1.json" \
-		1 $board
+for ult_case in ult no_ult; do
+    if [ "$ult_case" == "no_ult" ]; then
+        ult_switch="--no-unit-level-tests"
+    else
+        ult_switch=""
+    fi
 
-	python3 program_phsw_curves.py \
-		--pre-acquisition-time $pre_acquisition_time_proc2_s \
-		--turn-on \
-		--output "${output_dir}/phsw_curves_${board}_2_turnon.json" \
-		2 $board
+    for board in R O Y G B V I; do
+            python3 program_phsw_curves.py \
+                    --pre-acquisition-time $pre_acquisition_time_proc1_s \
+                    --output "${output_dir}/phsw_curves_${board}_1_${ult_case}.json" \
+                    ${ult_switch} \
+                    1 $board
 
-	python3 program_phsw_curves.py \
-		--pre-acquisition-time $pre_acquisition_time_proc2_s \
-		--output "${output_dir}/phsw_curves_${board}_2_no_turnon.json" \
-		2 $board
+            python3 program_phsw_curves.py \
+                    --pre-acquisition-time $pre_acquisition_time_proc2_s \
+                    --turn-on \
+                    --output "${output_dir}/phsw_curves_${board}_2_${ult_case}_turnon.json" \
+                    ${ult_switch} \
+                    2 $board
+
+            python3 program_phsw_curves.py \
+                    --pre-acquisition-time $pre_acquisition_time_proc2_s \
+                    --output "${output_dir}/phsw_curves_${board}_2_${ult_case}_no_turnon.json" \
+                    ${ult_switch} \
+                    2 $board
+    done
+
+    python3 program_phsw_curves.py \
+            --pre-acquisition-time $pre_acquisition_time_proc1_s \
+            --output "${output_dir}/phsw_curves_all_1_${ult_case}.json" \
+            ${ult_switch} \
+            1
+
+    python3 program_phsw_curves.py \
+            --pre-acquisition-time $pre_acquisition_time_proc2_s \
+            --turn-on \
+            --output "${output_dir}/phsw_curves_all_2_${ult_case}_turnon.json" \
+            ${ult_switch} \
+            2
+
+    python3 program_phsw_curves.py \
+            --pre-acquisition-time $pre_acquisition_time_proc2_s \
+            --output "${output_dir}/phsw_curves_all_2_${ult_case}_no_turnon.json" \
+            ${ult_switch} \
+            2
 done
-
-python3 program_phsw_curves1.py \
-	--pre-acquisition-time $pre_acquisition_time_proc1_s \
-	--output "${output_dir}/phsw_curves_all_1.json" \
-	1
-
-python3 program_phsw_curves2.py \
-	--pre-acquisition-time $pre_acquisition_time_proc2_s \
-	--turn-on \
-	--output "${output_dir}/phsw_curves_all_2_turnon.json" \
-	2
-
-python3 program_phsw_curves2.py \
-	--pre-acquisition-time $pre_acquisition_time_proc2_s \
-	--output "${output_dir}/phsw_curves_all_2_no_turnon.json" \
-	2


### PR DESCRIPTION
There are a few cases where there are no unit-level tests that contain meaningful PH/SW I-V curves. The new flag `--no-unit-level-tests` (shorthand `-n`) uses synthetic sequences of voltages/currents to produce the PH/SW JSON test scripts, instead of downloading these sequences from the unit-level test database.