### PR TITLE
Add a database of run logs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Welcome to Striptease's documentation!
    polarimeters
    data_interface
    procedures
+   runlog
    unittests
    development
 

--- a/dump_run_log.py
+++ b/dump_run_log.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# -*- encoding: utf-8 -*-
+
+from argparse import ArgumentParser
+from datetime import datetime
+from pathlib import Path
+from typing import List, Any, Dict
+
+from striptease import (
+    connect_to_run_log,
+    RunLogEntry,
+    RUN_LOG_DATETIME_FORMAT,
+    dump_procedure_as_json,
+)
+
+
+def entry_to_dict(entry: RunLogEntry) -> Dict[str, Any]:
+    return {
+        "id": entry.id,
+        "start_time": entry.start_time.strftime(RUN_LOG_DATETIME_FORMAT),
+        "end_time": entry.end_time.strftime(RUN_LOG_DATETIME_FORMAT),
+        "duration_s": (entry.end_time - entry.start_time).total_seconds(),
+        "wait_time_s": entry.wait_time_s,
+        "wait_cmd_time_s": entry.wait_cmd_time_s,
+        "full_path": str(entry.full_path),
+        "number_of_commands": entry.number_of_commands,
+    }
+
+
+def print_table(entries: List[RunLogEntry], output_file):
+    if not entries:
+        return
+
+    from rich.table import Table
+    from rich.console import Console
+
+    console = Console()
+
+    table = Table()
+    table.add_column("#")
+    table.add_column("Start time")
+    table.add_column("End time")
+    table.add_column("Duration (s)")
+    table.add_column("File name")
+    table.add_column("# of cmds")
+    table.add_column("Wait (s)")
+    table.add_column("Wait command (s)")
+
+    for entry in entries:
+        table.add_row(
+            str(entry.id),
+            entry.start_time.strftime(RUN_LOG_DATETIME_FORMAT),
+            entry.end_time.strftime(RUN_LOG_DATETIME_FORMAT),
+            "{:.1f}".format((entry.end_time - entry.start_time).total_seconds()),
+            Path(entry.full_path).name,
+            str(entry.number_of_commands),
+            "{:.2f}".format(entry.wait_time_s),
+            "{:.2f}".format(entry.wait_cmd_time_s),
+        )
+
+    console.print(table)
+
+
+def print_json(entries: List[RunLogEntry], output_file):
+    import json
+
+    json.dump([entry_to_dict(x) for x in entries], output_file)
+
+
+def print_csv(entries: List[RunLogEntry], output_file):
+    import csv
+
+    if not entries:
+        return
+
+    fieldnames = list(entry_to_dict(entries[0]).keys())
+    writer = csv.DictWriter(
+        output_file,
+        delimiter=",",
+        quotechar='"',
+        quoting=csv.QUOTE_NONNUMERIC,
+        fieldnames=fieldnames,
+    )
+
+    writer.writeheader()
+    writer.writerows([entry_to_dict(x) for x in entries])
+
+
+FORMAT_FN = {
+    "table": print_table,
+    "json": print_json,
+    "csv": print_csv,
+}
+
+
+def save_logged_procedure(blob: bytes, outf):
+    import pyzstd
+    import json
+
+    json_string = pyzstd.decompress(blob).decode("utf-8")
+    procedure = json.loads(json_string)
+    dump_procedure_as_json(outf=outf, obj=procedure)
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--format",
+        "-f",
+        metavar="IDENTIFIER",
+        default="table",
+        help="Select the output format. Possible values are"
+        + ", ".join(FORMAT_FN.keys()),
+    ),
+    parser.add_argument(
+        "--output",
+        "-o",
+        metavar="FILE",
+        default="",
+        help="Specify the name of the output file where to save the output",
+    )
+    parser.add_argument(
+        "--commands",
+        metavar="#",
+        default=None,
+        type=int,
+        help="If specified, dump the JSON commands ran for the entry number #",
+    )
+
+    args = parser.parse_args()
+
+    db = connect_to_run_log()
+    curs = db.cursor()
+
+    if args.commands:
+        curs.execute(
+            """
+SELECT zstd_json_procedure FROM run_log WHERE rowid = ?
+""",
+            (args.commands,),
+        )
+        blob = curs.fetchone()[0]
+
+        if args.output:
+            with open(args.output, "wt") as outf:
+                save_logged_procedure(blob=blob, outf=outf)
+        else:
+            from sys import stdout
+
+            save_logged_procedure(blob=blob, outf=stdout)
+
+        return
+
+    curs.execute(
+        """
+SELECT
+    rowid,
+    start_time,
+    end_time,
+    wait_time_s,
+    wait_cmd_time_s,
+    full_path,
+    number_of_commands
+FROM run_log
+ORDER BY start_time
+"""
+    )
+    entries = [
+        RunLogEntry(
+            id=row[0],
+            start_time=datetime.strptime(row[1], RUN_LOG_DATETIME_FORMAT),
+            end_time=datetime.strptime(row[2], RUN_LOG_DATETIME_FORMAT),
+            wait_time_s=row[3],
+            wait_cmd_time_s=row[4],
+            full_path=Path(row[5]),
+            number_of_commands=row[6],
+            zstd_json_procedure=None,
+        )
+        for row in curs.fetchall()
+    ]
+
+    if args.output:
+        with open(args.output, "wt") as outf:
+            FORMAT_FN[args.format](entries, outf)
+    else:
+        from sys import stdout
+
+        FORMAT_FN[args.format](entries, stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/striptease/__init__.py
+++ b/striptease/__init__.py
@@ -51,6 +51,13 @@ from .procedures import (
     dump_procedure_as_json,
     StripProcedure,
 )
+from .runlog import (
+    RUN_LOG_FILE_PATH,
+    RUN_LOG_DATETIME_FORMAT,
+    RunLogEntry,
+    connect_to_run_log,
+    append_to_run_log,
+)
 from .stripconn import (
     StripConnection,
     StripTag,
@@ -117,6 +124,12 @@ __all__ = [
     # procedures.py
     "dump_procedure_as_json",
     "StripProcedure",
+    # runlog.py
+    "RUN_LOG_FILE_PATH",
+    "RUN_LOG_DATETIME_FORMAT",
+    "RunLogEntry",
+    "connect_to_run_log",
+    "append_to_run_log",
     # stripconn.py
     "StripConnection",
     "StripTag",

--- a/striptease/runlog.py
+++ b/striptease/runlog.py
@@ -1,0 +1,102 @@
+from collections import namedtuple
+from datetime import datetime
+import json
+from pathlib import Path
+import pyzstd
+import sqlite3
+from typing import Any, List, Union
+
+"""A ``Path`` object that represents the SQLite3 database
+containing a log of all the procedures that have been ran.
+"""
+RUN_LOG_FILE_PATH = Path.home() / ".strip" / "run_log.db"
+
+RUN_LOG_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
+
+RunLogEntry = namedtuple(
+    "RunLogEntry",
+    [
+        "id",
+        "start_time",
+        "end_time",
+        "wait_time_s",
+        "wait_cmd_time_s",
+        "full_path",
+        "number_of_commands",
+        "zstd_json_procedure",
+    ],
+)
+
+
+def connect_to_run_log() -> sqlite3.Connection:
+    """Connect to the run log database or create one if it does not exist"""
+
+    run_log_dir = RUN_LOG_FILE_PATH.parent
+    run_log_dir.mkdir(parents=True, exist_ok=True)
+
+    db = sqlite3.connect(str(RUN_LOG_FILE_PATH))
+    curs = db.cursor()
+    curs.execute(
+        """
+CREATE TABLE IF NOT EXISTS run_log(
+    start_time TEXT,
+    end_time TEXT,
+    wait_time_s NUMBER,
+    wait_cmd_time_s NUMBER,
+    full_path TEXT,
+    number_of_commands NUMBER,
+    zstd_json_procedure BLOB
+)
+"""
+    )
+    db.commit()
+
+    return db
+
+
+def append_to_run_log(
+    start_time: datetime,
+    end_time: datetime,
+    wait_time_s: Union[int, float],
+    wait_cmd_time_s: Union[int, float],
+    full_path: str,
+    procedure: List[Any],
+):
+    """Add a new entry to the log of procedures that have been executed.
+
+    This function adds a new entry to the database that keeps track of all
+    the JSON procedures that have been executed by this user. The procedure
+    is saved in the database using the JSON format and the Zstandard
+    compression, and it should not take too much space (the average
+    compression ratio is ~10³).
+    """
+
+    json_proc = json.dumps(procedure)
+
+    db = connect_to_run_log()
+    curs = db.cursor()
+    curs.execute(
+        """
+INSERT INTO run_log VALUES (
+    :start_time,
+    :end_time,
+    :wait_time_s,
+    :wait_cmd_time_s,
+    :full_path,
+    :number_of_commands,
+    :zstd_json_procedure
+)
+        """,
+        {
+            "start_time": start_time.strftime(RUN_LOG_DATETIME_FORMAT),
+            "end_time": end_time.strftime(RUN_LOG_DATETIME_FORMAT),
+            "wait_time_s": wait_time_s,
+            "wait_cmd_time_s": wait_cmd_time_s,
+            "full_path": full_path,
+            "number_of_commands": len(procedure),
+            "zstd_json_procedure": pyzstd.compress(
+                json_proc.encode("utf-8"), level_or_option=12
+            ),
+        },
+    )
+    db.commit()


### PR DESCRIPTION
This PR adds the support for a «run log database», i.e., a database keeping track of all the JSON scripts that have been executed. For each run, the following information is recored:

1. Start and end time
2. Number of commands sent
3. Value of the overridden «wait time» and «wait command time» delay, which can be set when calling `program_batch_runner.py`
4. A compressed JSON representation of all the commands sent (the compression uses Zstandard at level 12, which ensures 10³ compression ratio)
5. The full path of the JSON file

Status of the PR:

- [X] Add support for a run log database
- [X] Make program_batch_runner.py use the run log database
- [x] Add the documentation
