### PR TITLE
Fix conversion from unsigned to signed in load_sci

### DIFF
--- a/striptease/hdf5files.py
+++ b/striptease/hdf5files.py
@@ -538,7 +538,7 @@ class DataFile:
         hk_data = datahk["value"]
         return hk_time, hk_data
 
-    def load_sci(self, polarimeter, data_type, detector=[], check_overflow=True):
+    def load_sci(self, polarimeter, data_type, detector=[]):
         """Loads scientific data from one detector of a given polarimeter
 
         Args:
@@ -555,10 +555,6 @@ class DataFile:
                 You can also pass a list, e.g., ``["Q1", "Q2"]``. If
                 no value is provided for this parameter, all the four
                 detectors will be returned.
-
-            check_overflow (bool): If ``True``, the sign of ``PWR`` data
-                will be checked that they do not overflow the
-                ``numpy.int32`` type.
 
         Returns:
 
@@ -619,14 +615,6 @@ class DataFile:
             column_selector = tuple([f"{data_type}{x}" for x in detector])
 
         converted_data = _unsigned_to_signed(scidata[column_selector])
-        if data_type == "PWR" and check_overflow:
-            if converted_data.dtype.names:
-                for cur_field in converted_data.dtype.names:
-                    assert np.all(
-                        converted_data[cur_field] >= 0
-                    ), f"Field {cur_field} has out-of-bounds values"
-            else:
-                assert np.all(converted_data >= 0), "Data have out-of-bounds values"
 
         return scitime, converted_data
 

--- a/striptease/hdf5files.py
+++ b/striptease/hdf5files.py
@@ -497,7 +497,7 @@ class DataFile:
         del self.hdf5_file
 
     def load_hk(self, group, subgroup, par, verbose=False):
-        """Loads scientific data from one detector of a given polarimeter
+        """Loads housekeeping data from one detector of a given polarimeter
 
         Args:
 

--- a/striptease/hdf5files.py
+++ b/striptease/hdf5files.py
@@ -538,7 +538,7 @@ class DataFile:
         hk_data = datahk["value"]
         return hk_time, hk_data
 
-    def load_sci(self, polarimeter, data_type, detector=[]):
+    def load_sci(self, polarimeter, data_type, detector=["Q1", "Q2", "U1", "U2"]):
         """Loads scientific data from one detector of a given polarimeter
 
         Args:
@@ -609,9 +609,6 @@ class DataFile:
 
             column_selector = f"{data_type}{detector}"
         else:
-            if not detector:
-                detector = ["Q1", "Q2", "U1", "U2"]
-
             column_selector = tuple([f"{data_type}{x}" for x in detector])
 
         converted_data = _unsigned_to_signed(scidata[column_selector])


### PR DESCRIPTION
Hi. This PR aims at fixing the problem in the `DataFile.load_sci()` function, which failed at converting unsigned data to signed. This seems to be due to the h5py library, therefore I moved the conversion after the column selection, which returns a numpy array. This allows us to use the `.astype()` method from numpy instead of the one from h5py. At the same time, I removed the now useless check for overflow (a quick search in the striptease library shows that it is not used anywhere in our programs).

Let me know if you prefer to leave a dummy `check_overflow` parameter to preserve compatibility with any possible program that is not in striptease and I am not aware of.

Thanks!