### PR TITLE
Add parse_polarimeters function to utilities

### DIFF
--- a/striptease/__init__.py
+++ b/striptease/__init__.py
@@ -75,6 +75,7 @@ from .utilities import (
     get_polarimeter_index,
     get_lna_num,
     get_lna_list,
+    parse_polarimeters,
     polarimeter_iterator,
 )
 
@@ -146,5 +147,6 @@ __all__ = [
     "get_polarimeter_index",
     "get_lna_num",
     "get_lna_list",
+    "parse_polarimeters",
     "polarimeter_iterator",
 ]

--- a/striptease/utilities.py
+++ b/striptease/utilities.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 from enum import IntEnum, IntFlag
+from typing import List
 
 #: List of all the board names: handy if you need to iterate over them,
 #: or if you need to validate user input
@@ -275,3 +276,74 @@ def polarimeter_iterator(
                 pol_name = BOARD_TO_W_BAND_POL[cur_board]
 
             yield cur_board, pol_idx, pol_name
+
+
+def parse_polarimeters(polarimeters: List[str]) -> List[str]:
+    """Parse a list of polarimeters, boards, "Q" (all Q polarimeters), "W" (all W polarimeters)
+    and (e.g.) "OQ", "OW" (all Q or W polarimeters in board O), and return a list of polarimeter names."""
+
+    all_polarimeters = [polarimeter for _, _, polarimeter in polarimeter_iterator()]
+    if polarimeters == []:
+        return []
+    if polarimeters[0] == "all":
+        return all_polarimeters
+
+    parsed_polarimeters = []
+    for item in polarimeters:
+        if not isinstance(item, str):
+            raise KeyError(f"polarimeter or board name {item} must be of str type")
+
+        # Check if item is a polarimeter name
+        try:
+            if normalize_polarimeter_name(item) in map(
+                normalize_polarimeter_name, all_polarimeters
+            ):
+                parsed_polarimeters.append(item)
+                continue
+        except KeyError:  # Continue if it is not
+            pass
+
+        # Check if item is a board name
+        if item in STRIP_BOARD_NAMES:
+            parsed_polarimeters += [
+                polarimeter for _, _, polarimeter in polarimeter_iterator(boards=[item])
+            ]
+
+        # Check if item is "Q", meaning all Q polarimeters
+        elif item == "Q":
+            parsed_polarimeters += [
+                polarimeter
+                for _, _, polarimeter in polarimeter_iterator(include_w_band=False)
+            ]
+
+        # Check if item is "W", meaning all W polarimeters
+        elif item == "W":
+            parsed_polarimeters += [
+                polarimeter
+                for _, _, polarimeter in polarimeter_iterator(include_q_band=False)
+            ]
+
+        # Check if item is of the form f"{board}Q", meaning all Q polarimeters on the board
+        elif len(item) == 2 and item[1] == "Q":
+            parsed_polarimeters += [
+                polarimeter
+                for _, _, polarimeter in polarimeter_iterator(
+                    boards=[item[0]], include_w_band=False
+                )
+            ]
+
+        # Check if item is of the form f"{board}W", meaning all W polarimeters on the board
+        elif len(item) == 2 and item[1] == "W":
+            parsed_polarimeters += [
+                polarimeter
+                for _, _, polarimeter in polarimeter_iterator(
+                    boards=[item[0]], include_q_band=False
+                )
+            ]
+
+        else:
+            raise KeyError(f"unknown polarimeter or board {item}")
+
+    return list(
+        dict.fromkeys(parsed_polarimeters)
+    )  # Return list removing duplicate polarimeters


### PR DESCRIPTION
Hi! This PR adds a utility function to parse a list of polarimeters and board names into a list of polarimeters. It recognizes the "all" keyword, all polarimeter and board names, "Q" for all Q polarimeters, "W" for all W polarimeters, `f"{board}Q"` and `f"{board}W"` for all Q or W polarimeters in the board. If there is a more standard nomenclature, especially for the last case, I can change it accordingly. Let me know! Thanks.