### PR TITLE
Save run-length encoded times in HDF5 files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ sphinxcontrib.asciinema~=0.3.3
 telegram-send~=0.34
 Jinja2~=3.1.2
 python-telegram-bot~=13.5
+numba~=0.56

--- a/striptease/__init__.py
+++ b/striptease/__init__.py
@@ -32,6 +32,7 @@ from .diagnostics import (
 from .hdf5db import (
     DataStorage,
     HDF5FileInfo,
+    scan_data_path,
 )
 from .hdf5files import (
     HDF5_GZIP_FILE_SUFFIXES,
@@ -46,6 +47,11 @@ from .hdf5files import (
     get_group_subgroup,
     get_hk_descriptions,
     DataFile,
+)
+from .rle import (
+    RunLengthTime,
+    compress_times_rle,
+    decompress_times_rle,
 )
 from .procedures import (
     dump_procedure_as_json,
@@ -125,6 +131,10 @@ __all__ = [
     # procedures.py
     "dump_procedure_as_json",
     "StripProcedure",
+    # rle.py
+    "RunLengthTime",
+    "compress_times_rle",
+    "decompress_times_rle",
     # runlog.py
     "RUN_LOG_FILE_PATH",
     "RUN_LOG_DATETIME_FORMAT",

--- a/striptease/hdf5db.py
+++ b/striptease/hdf5db.py
@@ -161,13 +161,16 @@ def scan_data_path(
                 },
             )
 
-            if update_hdf5 and computed:
+            if computed:
                 log.info(
                     f'Writing MJD range ({first_sample}, {last_sample}) back in "{file_name}"'
                 )
                 with DataFile(file_name, "r+") as hdf5:
                     hdf5.hdf5_file.attrs["FIRST_SAMPLE"] = first_sample
                     hdf5.hdf5_file.attrs["LAST_SAMPLE"] = last_sample
+
+            with DataFile(file_name, "r+") as hdf5:
+                hdf5.add_rle_times(force=update_hdf5)
 
             # If a tag is not closed when a HDF5 file is being opened, the
             # tag is left open and it will be properly closed in the next file.

--- a/striptease/hdf5files.py
+++ b/striptease/hdf5files.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from scipy.interpolate import interp1d
 
 from .biases import BiasConfiguration
+from .rle import RunLengthTime, decompress_times_rle
 
 
 # Any MJD value smaller than this will be considered invalid. We must
@@ -363,6 +364,22 @@ def _open_file(filepath, filemode):
     return h5py.File(stream, filemode)
 
 
+def _load_times(hdf5_pol_group) -> Time:
+    try:
+        time_interval = hdf5_pol_group["rle_time_interval"]
+        time_nsamples = hdf5_pol_group["rle_time_nsamples"]
+
+        rle = RunLengthTime(
+            start_times=Time(time_interval[:, 0], format="mjd"),
+            end_times=Time(time_interval[:, 1], format="mjd"),
+            run_lengths=time_nsamples,
+        )
+
+        return decompress_times_rle(rle)
+    except KeyError:
+        return Time(hdf5_pol_group["pol_data"]["m_jd"], format="mjd")
+
+
 class DataFile:
     """A HDF5 file containing timelines acquired by Strip
 
@@ -628,7 +645,7 @@ class DataFile:
         pol_group = self.hdf5_file[polarimeter]
         scidata = pol_group["pol_data"]
 
-        scitime = Time(scidata["m_jd"], format="mjd")
+        scitime = _load_times(pol_group)
 
         if isinstance(detector, str):
             if not detector.upper() in VALID_DETECTORS:
@@ -715,3 +732,51 @@ class DataFile:
                 result[x] = average
 
         return BiasConfiguration(**result)
+
+    def add_rle_times(self, force=False):
+        """Add a RLE-compressed copy of each time column for the scientific datasets
+
+        This function modifies the HDF5 file, so you must have opened it in ``r+`` mode. Once
+        the RLE-compressed datasets have been saved to disk, loading chunks of data from them
+        will be orders of magnitude faster.
+
+        If the `force` flag is ``True``, existing RLE compressed streams will be overwritten.
+        """
+
+        from striptease import polarimeter_iterator, compress_times_rle
+
+        if not self.hdf5_groups:
+            self.read_file_metadata()
+
+        for _, _, pol_name in polarimeter_iterator():
+            hdf5_pol_group = f"POL_{pol_name}"
+            if hdf5_pol_group not in self.hdf5_file:
+                continue
+
+            pol_group = self.hdf5_file[hdf5_pol_group]
+
+            if (not force) and ("rle_time_interval" in pol_group):
+                continue
+
+            time = Time(pol_group["pol_data"]["m_jd"], format="mjd")
+            if (not time) or (len(time) == 0):
+                continue
+
+            rle = compress_times_rle(time)
+
+            if force:
+                try:
+                    del pol_group["rle_time_interval"]
+                except KeyError:
+                    pass
+
+                try:
+                    del pol_group["rle_time_nsamples"]
+                except KeyError:
+                    pass
+
+            time_matrix = np.stack(
+                (rle.start_times.to_value("mjd"), rle.end_times.to_value("mjd"))
+            ).transpose()
+            pol_group.create_dataset("rle_time_interval", data=time_matrix)
+            pol_group.create_dataset("rle_time_nsamples", data=rle.run_lengths)

--- a/striptease/rle.py
+++ b/striptease/rle.py
@@ -1,0 +1,126 @@
+# -*- encoding: utf-8 -*-
+
+from dataclasses import dataclass
+
+import astropy.time as astrotime
+import numpy as np
+from numba import njit
+
+
+def _get_default_delta_time_s(time: astrotime.Time) -> float:
+    "Estimate the average time interval between consecutive samples"
+    return float(np.median((time[1:] - time[0:-1]).to("s").value))
+
+
+@njit
+def _find_consecutive_chunks(
+    arr, expected_increment: float, output_runs, relative_tolerance: float = 0.1
+):
+    """
+    Find the length of each run of uniformly-sampled values in `arr`
+
+    This function detects runs of values in `arr` whose consecutive differences is approximately
+    the same. The relative tolerance in the comparison is set through the `tolerance_factor`;
+    setting it to 0 means that
+    """
+    output_idx = 0
+    run_length = 1
+
+    for i in range(1, len(arr)):
+        if (arr[i] - arr[i - 1]) > ((1.0 + relative_tolerance) * expected_increment):
+            # We got a time jump
+            output_runs[output_idx] = run_length
+            output_idx += 1
+            run_length = 1
+        else:
+            run_length += 1
+
+    output_runs[output_idx] = run_length
+    output_idx += 1
+
+    return output_idx
+
+
+@dataclass
+class RunLengthTime:
+    """An array of astropy.time.Time values, compressed using the Run-Length Encoding algorithm
+
+    Objects of this type are created using the :func:`.compress_times_rle`. They can be decompressed
+    back using :func:`.decompress_times_rle`.
+
+    The original Run-Length Encoding (RLE) algorithm works by finding sequences of repeated values and compressing
+    them into a pair ``(value, count)``. If there are many repetitions in the sequence, the compression factor
+    can be excellent.
+
+    When compressing array of *times*, we consider repetitions in the interval between consecutive samples,
+    so it's not strictly a RLE algorithm.
+
+    The stream of times is encoded as a sequence of “chunks”; within each chunk, the sampling frequency is
+    constant and free of gaps, so that it is enough to encode the value of the first (`start_times`) and
+    last sample (`end_times`) in the chunk as well as the number of samples (`run_lengths`).
+
+    For instance, consider the following sequence of times, acquired once every second::
+
+        0, 1, 2, 3,    7, 8,    10, 11,    15,    21, 22, 23
+
+    (Spaces have been added to highlight where the sequence has a discontinuity). The representation of this
+    sequence using the class :`RunLengthTime` is the following::
+
+        start_times = [0, 7, 11, 15, 21]
+        end_times = [3, 8, 11, 15, 23]
+        run_lengths = [4, 2, 2, 1, 3]
+    """
+
+    start_times: astrotime.Time
+    end_times: astrotime.Time
+    run_lengths: np.array
+
+
+def compress_times_rle(
+    time: astrotime.Time, dtype="int32", relative_tolerance: float = 0.1
+) -> RunLengthTime:
+    "Compress an array of times in a :class:`.RunLengthTime` object"
+
+    time_s = (time - time[0]).to("s").value
+    output_runs = np.empty(len(time), dtype=dtype)
+    default_delta_time_s = _get_default_delta_time_s(time)
+    num_of_chunks = _find_consecutive_chunks(
+        time_s,
+        expected_increment=default_delta_time_s,
+        output_runs=output_runs,
+        relative_tolerance=relative_tolerance,
+    )
+    output_runs = output_runs[0:num_of_chunks]
+
+    result = RunLengthTime(
+        start_times=astrotime.Time(np.zeros(len(output_runs)), format="mjd"),
+        end_times=astrotime.Time(np.zeros(len(output_runs)), format="mjd"),
+        run_lengths=output_runs,
+    )
+    result.start_times[0] = time[0]
+    cur_idx = 0
+    for idx, cur_run_length in enumerate(output_runs):
+        result.start_times[idx] = time[cur_idx]
+        result.end_times[idx] = time[cur_idx + cur_run_length - 1]
+        cur_idx += cur_run_length
+
+    return result
+
+
+def decompress_times_rle(rle: RunLengthTime) -> astrotime.Time:
+    assert len(rle.run_lengths) == len(rle.end_times)
+    assert len(rle.end_times) == len(rle.start_times)
+
+    num_of_samples = np.sum(rle.run_lengths)
+    result = astrotime.Time(np.zeros(num_of_samples), format="mjd")
+
+    cur_sample_idx = 0
+    for cur_chunk_len, cur_start_time, cur_end_time in zip(
+        rle.run_lengths, rle.start_times, rle.end_times
+    ):
+        result[cur_sample_idx : (cur_sample_idx + cur_chunk_len)] = np.linspace(
+            cur_start_time, cur_end_time, num=cur_chunk_len
+        )
+        cur_sample_idx += cur_chunk_len
+
+    return result


### PR DESCRIPTION
Currently the code is extremely slow in loading scientific data from HDF5 files. Even if you are interested in a few seconds of data and know the extrema of the time interval, the whole timestream of data (~4 hours) needs to be loaded in memory.

This PR adds the ability to save a Run-Length Encoded (RLE) version of the time stream of each polarimeter in the same HDF5 file. It is typically done when the SQLite3 database used by `DataStorage` is created. Once the RLE timeline is saved, it will be used whenever scientific data for a specific range of time are requested either by `DataFile.load_sci` or `DataStorage.load_sci`. This should reduce the time needed for I/O considerably, expecially if the chunk of data is small.
